### PR TITLE
Test関数にTypeGuardを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
     "copy-rust_js": "ncp ./pkg/circuitgame_lib.js ./dist/circuitgame_lib.js",
     "copy-rust_dts": "ncp ./pkg/circuitgame_lib.d.ts ./src/circuitgame_lib.d.ts",
     "copy-rust_wasm": "npx wasm-opt -Oz ./pkg/circuitgame_lib_bg.wasm -o ./dist/circuitgame_lib_bg.wasm",
-    "copy-rust": "npm run copy-rust_js && npm run copy-rust_wasm",
+    "copy-rust": "npm run copy-rust_js && npm run copy-rust_dts && npm run copy-wasm_dts && npm run copy-rust_wasm",
+    "copy-assets": "npm run copy-html && npm run copy-sample",
     "copy-html": "ncp ./src/index.html ./dist/index.html",
     "copy-sample": "ncp ./spec/sample.ncg ./dist/sample.ncg",
-    "build": "npm install && npm run build-rust && npm run copy-rust_dts && npm run build-ts && npm run copy-rust && npm run copy-html && npm run copy-sample",
+    "build": "npm install && npm run build-rust && npm run copy-rust && npm run build-ts && npm run copy-assets",
     "server": "http-server ./dist",
     "clean": "npx rimraf target pkg node_modules",
     "install-rust": "bash -c \"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh\""

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import init, { Compile, CompilerIntermediateProducts, Test } from './circuitgame_lib.js';
-import { isIntermediateProducts } from './typeGuards.js';
-import { IntermediateProducts } from './types.js';
+import { isIntermediateProducts, isTestProducts } from './typeGuards.js';
+import { IntermediateProducts, TestProducts } from './types.js';
 
 function CompileAsTypescriptResult(code: string): IntermediateProducts {
     let result_from_rust: any = JSON.parse(CompilerIntermediateProducts(code));
@@ -9,6 +9,13 @@ function CompileAsTypescriptResult(code: string): IntermediateProducts {
         throw new Error('Rustからの返り値が期待する形式と一致しません');
     }
     return result_from_rust;
+}
+function TestAsTypescriptResult(input: string): TestProducts {
+    let result_from_rust: any = JSON.parse(Test(input));
+    if (!isTestProducts(result_from_rust)) {
+        throw new Error('Rustからの返り値が期待する形式と一致しません');
+    }
+    return result_from_rust
 }
 
 async function fetchTextFile(url: string): Promise<string> {
@@ -38,13 +45,13 @@ async function run() {
         const result = CompileAsTypescriptResult(input);
         console.log(result);
         console.log(result.module_dependency_sorted[0]);
-        const test_result = JSON.parse(Test(input));
+        const test_result = TestAsTypescriptResult(input);
         console.log(test_result);
         for (let name of Object.keys(test_result.test_result)) {
             console.log(`test: ${name}`);
             console.table(test_result.test_result[name]);
         }
-        console.log(Compile(input,result.module_dependency_sorted[0]));
+        console.log(Compile(input, result.module_dependency_sorted[0]));
     }
 }
 

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,4 +1,4 @@
-import { Component, File, Gate, IntermediateProducts, Module, ModuleType, MType, NodeDepends, Test, Using } from './types';
+import { Component, File, Gate, IntermediateProducts, Module, ModuleType, MType, NodeDepends, Test, TestProducts, Using } from './types';
 
 export function isIntermediateProducts(obj: any): obj is IntermediateProducts {
     if (!obj || typeof obj !== 'object') return false;
@@ -92,4 +92,34 @@ export function isTest(obj: any): obj is Test {
             Array.isArray(p.outputs) &&
             p.outputs.every(o => typeof o === 'boolean')
         );
-} 
+}
+
+export function isTestProducts(obj: any): obj is TestProducts {
+    if (!obj || typeof obj !== 'object') return false;
+
+    // 必須プロパティの存在チェック
+    if (!('warns' in obj && 'errors' in obj && 'test_list' in obj && 'test_result' in obj)) return false;
+
+    // 配列プロパティの型チェック
+    if (!Array.isArray(obj.warns) || !obj.warns.every(w => typeof w === 'string')) return false;
+    if (!Array.isArray(obj.errors) || !obj.errors.every(e => typeof e === 'string')) return false;
+    if (!Array.isArray(obj.test_list) || !obj.test_list.every(t => typeof t === 'string')) return false;
+
+    // test_resultの型チェック
+    if (typeof obj.test_result !== 'object') return false;
+
+    // test_resultの各要素（TestPattern[]）をチェック
+    return Object.values(obj.test_result).every(patterns => {
+        if (!Array.isArray(patterns)) return false;
+        return patterns.every(pattern =>
+            typeof pattern === 'object' &&
+            typeof pattern.accept === 'boolean' &&
+            Array.isArray(pattern.input) &&
+            pattern.input.every(i => typeof i === 'boolean') &&
+            Array.isArray(pattern.expect) &&
+            pattern.expect.every(e => typeof e === 'boolean') &&
+            Array.isArray(pattern.output) &&
+            pattern.output.every(o => typeof o === 'boolean')
+        );
+    });
+}  

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,21 @@ export interface IntermediateProducts {
     module_dependency: NodeDepends[];
     module_dependency_sorted: string[];
 }
+
+export type TestPattern = {
+    accept: Boolean;
+    input: Boolean[];
+    expect: Boolean[];
+    output: Boolean[];
+}
+
+export type TestPatternMap = {
+    [key: string]: TestPattern[];
+}
+
+export type TestProducts = {
+    warns: string[];
+    errors: string[];
+    test_list: string[];
+    test_result: TestPatternMap
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "lib": ["dom", "es2016"],
+        "lib": ["dom", "es2017"],
         "module": "esnext",
         "moduleResolution": "node",
         "outDir": "./dist",


### PR DESCRIPTION
1. package.jsonのscriptsを整理
2. typeguard関数を作成
3. es2016 -> es2017
 - `Object.values()`が使いたかった